### PR TITLE
Corrected the setup instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ cd pullup
 # Install NPM dependencies
 npm install
 
-node app.js
-```
-
-To log in to your development instance you'll need to create a GitHub application and set the following environment variables:
+# Register a new application on GitHub (https://github.com/settings/applications) 
+# Now that you have your application setup you can set the following environment variables:
 
 ```bash
 export GITHUB_CLIENTID='CLIENTID'
 export GITHUB_SECRET='SECRET'
 ```
+# Once those are set you can run the local development version
+node app.js
+
 
 Lots more technical details [here](https://github.com/larvalabs/pullup/blob/master/hackathon-starter-readme.md).
 

--- a/config/userlist.js
+++ b/config/userlist.js
@@ -4,6 +4,7 @@ module.exports = {
 		'pents90',
 		'michaelnovakjr',
 		'markbao',
+		'dcancel',
 		'lablayers'
 	]
 };


### PR DESCRIPTION
The environment variables need to be set before running node app.js to
prevent an OAUTH error message.

Error message before changing the order of the steps:

pullup/node_modules/passport-github/node_modules/passport-oauth/lib/passport-oauth/strategies/oauth2.js:66
  if (!options.clientID) throw new Error('OAuth2Strategy requires a clientID o
                               ^
Error: OAuth2Strategy requires a clientID option
