### PR TITLE
Fix the scoring function for items with 0 or 1 vote. Fix #77

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -83,8 +83,7 @@ function sortByScore(newsItems, user, callback) {
 
     var now = new Date();
     newsItems = newsItems.map(function (item) {
-      var ageInHours = (now.getTime() - item.created.getTime()) / 3600000;
-      item.score = (item.votes - 1) / Math.pow(ageInHours + 2, gravity);
+      calculateScore(item, now, gravity);
       return item;
     });
 
@@ -95,6 +94,15 @@ function sortByScore(newsItems, user, callback) {
 
     callback(null, newsItems);
   });
+}
+
+function calculateScore(item, now, gravity) {
+  var votes = item.votes;
+  if (votes === 0) {
+    votes = 0.1;
+  }
+  var ageInHours = (now.getTime() - item.created.getTime()) / 3600000;
+  item.score = votes / Math.pow(ageInHours + 2, gravity);
 }
 
 function addVotesToNewsItems(newsItems, user, callback) {


### PR DESCRIPTION
The scoring algorithm wasn't really handling scores of 0 or 1 correctly. I took the original algorithm without modification from Hacker News, and all of their links start with a score of 1.

Fixes #77 
