### PR TITLE
Vote for a News Item when it's submitted

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -332,8 +332,19 @@ exports.postNews = function(req, res, next) {
         return res.redirect('/news/submit');
       }
     } else {
-      req.flash('success', { msg: 'News item submitted. Thanks!' });
-      res.redirect('/news');
+      // cast an initial vote for a submitted story
+      var vote = new Vote({
+        item: newsItem,
+        voter: req.user.id,
+        amount: 1
+      });
+
+      vote.save(function (err) {
+        if (err) return res.redirect('/news/submit');
+
+        req.flash('success', { msg: 'News item submitted. Thanks!' });
+        res.redirect('/news');
+      });
     }
   });
 


### PR DESCRIPTION
This change casts an immediate vote for a news item from the submitter when it's submitted. The result is that you can't vote for your own news items (which was kind of weird anyway), and every news item has a score of at least 1, which I think will help some of the sorting, which seemed to still be a little bit off.
