### PR TITLE
Assert user.id present when posting a comment

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -95,6 +95,7 @@ exports.comments = function (req, res, next) {
 
 exports.postComment = function (req, res, next) {
   req.assert('contents', 'Comment cannot be blank.').notEmpty();
+  req.assert(['user','id'], 'You must be logged in to post a comment.').notEmpty();
 
   var errors = req.validationErrors();
 


### PR DESCRIPTION
Fix for #102

Assert user.id presence. Otherwise a TypeError is returned when a user is not logged in and attempts to post.
