### PR TITLE
[CSS] Minor change to the table styling to align items using middle, rat...

### DIFF
--- a/public/css/lib/bootstrap/tables.less
+++ b/public/css/lib/bootstrap/tables.less
@@ -26,7 +26,7 @@ th {
       > td {
         padding: @table-cell-padding;
         line-height: @line-height-base;
-        vertical-align: top;
+        vertical-align: middle;
         border-top: 1px solid @table-border-color;
       }
     }


### PR DESCRIPTION
Minor change to the table styling to align items using 'middle', rather than 'top'. 

Here is before: https://www.dropbox.com/s/iribmeaf6w50i42/Screenshot%202014-02-11%2014.42.09.png and here is after: https://www.dropbox.com/s/hg4eyo20x0gg87s/Screenshot%202014-02-11%2014.41.29.png

It's a small change but I think it helps quite a bit.
