### PR TITLE
Revert removed spaces from f97b95c

### DIFF
--- a/config/userlist.js
+++ b/config/userlist.js
@@ -1,5 +1,6 @@
 module.exports = {
     users: [ // ADD YOUR USERNAME AT THE TOP
+        'jtokoph',
         'gwillen',
         'isaaczafuta',
         'bluetidepro',

--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -17,11 +17,11 @@ block content
                 br
                 p(class='hidden summary')
                     em= item.summary
-        | submitted
+        | submitted&nbsp;
         span.timeago(title="#{item.created}")= timeago(item.created)
-        |  by
+        |  by&nbsp;
         a(href='/news/user/' + item.poster.username)= item.poster.username
-        |  from
+        |  from&nbsp;
         a(href='/news/source/' + item.source)= item.source
     if user
         .row


### PR DESCRIPTION
I re-added the trailing spaces as an html entitity (nbsp) in order to prevent them from being automatically removed by an editor again.

These were removed as part of f97b95c (most likely due to automatic trailing space removal plugin)
