### PR TITLE
Fixed a bug with the frontpage when there are no news in the database

### DIFF
--- a/config/userlist.js
+++ b/config/userlist.js
@@ -1,5 +1,6 @@
 module.exports = {
     users: [ // ADD YOUR USERNAME AT THE TOP
+        'marco-fiset',
         'jeromegn',
         'mattclaw',
         'crankeye',

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -22,6 +22,13 @@ exports.index = function(req, res, next) {
 
       if(err) return next(err);
 
+      if (!newsItems.length) {
+        return res.render('news/index', {
+            title: 'Recent News',
+            items: newsItems
+          });
+      }
+
       var counter = newsItems.length;
 
       _.each(newsItems, function (newsItem) {


### PR DESCRIPTION
I had a "No data received" error from '/' and '/news' pages, although the rest of the application worked properly. The bug happens when there are no news items, since the rendering is done inside of the _.each() callback.
