### PR TITLE
Fix spacing in comments view

### DIFF
--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -17,11 +17,11 @@ block content
                 br
                 p(class='hidden summary')
                     em= item.summary
-        | submitted
+        = 'submitted '
         span.timeago(title="#{item.created}")= timeago(item.created)
-        |  by
+        = ' by '
         a(href='/news/user/' + item.poster.username)= item.poster.username
-        |  from
+        = ' from '
         a(href='/news/source/' + item.source)= item.source
     if user
         .row


### PR DESCRIPTION
I think this approach is a bit better than #154 since it doesn't result in trailing whitespace, which is probably the reason the spacing was broken in the first place.
