### PR TITLE
Adds rudimentary Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install gulp -g

--- a/config/passport.js
+++ b/config/passport.js
@@ -60,7 +60,7 @@ passport.use(new FacebookStrategy(secrets.facebook, function (req, accessToken, 
     });
   } else {
     User.findOne({ facebook: profile.id }, function(err, existingUser) {
-      console.log(profile)
+      console.log(profile);
       if (existingUser) return done(null, existingUser);
       var user = new User();
       user.email = profile._json.email;

--- a/config/userlist.js
+++ b/config/userlist.js
@@ -47,6 +47,7 @@ module.exports = {
         'tejohnso',
         'theprofessor117',
         'tito0224',
+        'travishorn',
         'treygriffith',
         'williamle8300'
     ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,8 +2,17 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var jshint = require('gulp-jshint');
 
-gulp.task('default', function(){
-    gulp.src('./controllers/*.js')
+var paths = {
+    scripts: ['./*.js', 'config/**/*.js', 'controllers/**/*.js', 'models/**/*.js', 'public/js/**/*.js', '!public/js/lib/**/*.js']
+};
+
+gulp.task('test', function () {
+    gulp.src(paths.scripts)
         .pipe(jshint())
-        .pipe(jshint.reporter('default'));
+        .pipe(jshint.reporter('default'))
+        .pipe(jshint.reporter('fail'));
+});
+
+gulp.task('default', function(){
+    gulp.start('test');
 });

--- a/models/Vote.js
+++ b/models/Vote.js
@@ -1,5 +1,5 @@
-var mongoose = require('mongoose')
-  , Schema = mongoose.Schema;
+var mongoose = require('mongoose'),
+    Schema = mongoose.Schema;
 
 
 var voteSchema = new mongoose.Schema({

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/larvalabs/pullup.git"
   },
+  "scripts": {
+    "test": "gulp test"
+  },
   "dependencies": {
     "async": "~0.2.10",
     "bcrypt-nodejs": "~0.0.3",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,22 +5,22 @@ $(document).ready(function() {
       var url = $("#url").val();
       $.get("/news/summarize?url=" + url, function(response) {
         if (response) {
-		  if(typeof response.title !== "undefined"){
+      if(typeof response.title !== "undefined"){
 			$("#title").val(response.title);
-		  }
-		  
-		  if(typeof response.source !== "undefined"){
+      }
+     
+      if(typeof response.source !== "undefined"){
 			$("#source").val(response.source);
-		  }
-		  else $("#source").val(url);
-		  
-		  if(typeof response.summary !== "undefined"){
+      }
+      else $("#source").val(url);
+      
+      if(typeof response.summary !== "undefined"){
 			$("#summary").val(response.summary.join(" "));
-		  }
+      }
         
 		}
       });
-    })
+    });
     $('input[autofocus]').trigger('focus');//force fire it on the autofocus element
   }
 
@@ -28,7 +28,7 @@ $(document).ready(function() {
     $(".show-summary").on('click', function(e) {
       e.preventDefault();
       $(this).siblings("p").toggleClass('hidden');
-    })
+    });
   }
 
   $("#copyright").text(new Date().getFullYear());


### PR DESCRIPTION
The only test Travis-CI will run right now is linting with JSHint. I modified the gulpfile to include all current .js files, excluding vendor libraries. In order for JSHint to pass (using default settings), I had to de-lint many files (missing semicolons, etc). This commit also adds an NPM "test" script that will just run "gulp test".

In order for Travis-CI to run, you will need to create a Travis-CI account (if you don't already have one) and enable it for this repository by going to http://travis-ci.org > Sign in > hover over your account name > Accounts > flip the switch to "on" for "pullup".

The next step is to enable the Travis-CI web hook on GitHub by going to the repository's settings > Webhooks & Services > Configure services > Travis.

Enter your Travis-CI user name (probably same as GitHub), and your token (found at https://travis-ci.org/profile/[user]/profile), check the "Active" box and update settings. Once this is all set up, you may consider [adding a Travis-CI badge](http://docs.travis-ci.com/user/status-images/) to the README.md file.
