### PR TITLE
Fix crashing error on news index from deleted user's posts

### DIFF
--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -69,8 +69,12 @@ block content
                         span
                             small.submit-date(title="#{item.created}")= timeago(item.created)
                             small #{' '}by#{' '}
-                            a(href='/news/user/' + item.poster.username)
-                                small #{item.poster.username}
+                            if item.poster
+                                a(href='/news/user/' + item.poster.username)
+                                    small #{item.poster.username}
+                            else
+                                span.text-muted
+                                    | [deleted]
                             small #{' '}with#{' '}
                             a(href='/news/' + item._id)
                                 case item.comment_count


### PR DESCRIPTION
Simply replaced the user link with the text '[deleted]'

Fixes #166
