### PR TITLE
Minor Style tweaks

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -179,6 +179,11 @@ body {
   text-shadow: 1px 1px 0px #2D81B9;
 }
 
+// Override color: inherit to make the close button actually visible
+.alert-dismissable .close {
+  color: #000;
+}
+
 // Extra space between font-awesome icons and text
 [class^="fa-"],
 [class*="fa-"] {


### PR DESCRIPTION
Improved crispness and readability of a few links and buttons. Namely, 'info' buttons (I only noticed any on the 'About' page), visited links, and links in the main navbar.  I tried to make the shadows non-obvious since Pullup is using a flat style, but I felt they made the text appear crisper and much easier to read.  The visited links I just darkened a bit to make them easier to read against the white background.
