### PR TITLE
Tweaked Line Height of comment delete buttons to center the text better

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -91,7 +91,7 @@ body {
 
 .news-item .comment .delete {
   font-size: 12px;
-  line-height: 1;
+  line-height: 0.9;
   padding: 2px;
   width: 17px; height: 17px;
   border-radius: 50%;


### PR DESCRIPTION
I almost left this for someone else, but it was driving me nuts...
This makes the `x` in the delete button more centered vertically.

Before
![delete_button_before](https://f.cloud.github.com/assets/315948/2162006/0ffb2984-94cd-11e3-9d22-11cf9e4edc81.png)
After
![delete_button_after](https://f.cloud.github.com/assets/315948/2162008/11e78102-94cd-11e3-93fc-6887fe932478.png)
