### PR TITLE
Align the navbar text baselines

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -48,6 +48,10 @@ body {
   text-shadow: 1px 1px 0px rgba(3, 85, 69, 0.2);
 }
 
+.navbar-brand {
+  line-height: 0.93em;
+}
+
 // News Table
 // -------------------------
 .news-table a:visited {


### PR DESCRIPTION
The baseline for 'pullup' in the nav bar's baseline did not align with the rest of the text.
It was driving me nuts so I fixed it.

![untitled](https://f.cloud.github.com/assets/113860/2164590/c7308728-94ed-11e3-8645-bf5e949ef34e.png)
