### PR TITLE
Remove "Linked Accounts" and "Change Password" Sections from Profile

### DIFF
--- a/views/account/profile.jade
+++ b/views/account/profile.jade
@@ -6,11 +6,7 @@ block content
       li.active
         a(href="#profile-information", data-toggle="tab") Profile Information
       li
-        a(href="#change-password", data-toggle="tab") Change Password
-      li
         a(href="#delete-account", data-toggle="tab") Delete Account
-      li
-        a(href="#linked-accounts", data-toggle="tab") Linked Accounts
 
   .col-md-9.tab-content
     #profile-information.tab-pane.active
@@ -53,23 +49,6 @@ block content
           .col-xs-offset-0.col-xs-12.col-sm-offset-2.col-sm-4
             button.btn.btn.btn-primary(type='submit') Update Profile
 
-    #change-password.tab-pane
-      .page-header
-        h3 Change Password
-
-      form.form-horizontal(action='/account/password', method='POST')
-        .form-group
-          label.col-xs-12.col-sm-2.control-label(for='password') New Password
-          .col-xs-12.col-sm-4
-            input.form-control(type='password', name='password', id='password')
-        .form-group
-          label.col-xs-12.col-sm-2.control-label(for='confirmPassword') Confirm Password
-          .col-xs-12.col-sm-4
-            input.form-control(type='password', name='confirmPassword', id='confirmPassword')
-        .form-group
-          .col-xs-offset-0.col-xs-12.col-sm-offset-2.col-sm-4
-            button.btn.btn.btn-primary(type='submit') Change Password
-
     #delete-account.tab-pane
       .page-header
         h3 Delete Account
@@ -89,27 +68,3 @@ block content
               form(action='/account/delete', method='POST')
                 button.btn.btn-danger(type='submit') I understand, delete my account
             .modal-footer
-
-    #linked-accounts.tab-pane
-      .page-header
-        h3 Linked Accounts
-
-      if user.google
-        p: a.text-danger(href='/account/unlink/google') Unlink your Google account
-      else
-        p: a(href='/auth/google') Link your Google account
-
-      if user.facebook
-        p: a.text-danger(href='/account/unlink/facebook') Unlink your Facebook account
-      else
-        p: a(href='/auth/facebook') Link your Facebook account
-
-      if user.twitter
-        p: a.text-danger(href='/account/unlink/twitter') Unlink your Twitter account
-      else
-        p: a(href='/auth/twitter') Link your Twitter account
-
-      if user.github
-        p: a.text-danger(href='/account/unlink/github') Unlink your GitHub account
-      else
-        p: a(href='/auth/github') Link your GitHub account


### PR DESCRIPTION
We are only using Github as the method for logging-in, making the other potential account links and the ability to change your password extraneous. These have been removed to simply the profile page.

[via #58, #219]
