### PR TITLE
Fix tabs on profile page

### DIFF
--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -100,7 +100,7 @@ block content
                                 a(href='/news/source/' + item.source)
                                     | #{item.source}
 
-    if filteredUser
+      if filteredUser
         div#comments.tab-pane.fade
             table.table.table-condensed
                 thead


### PR DESCRIPTION
Some merge conflict resolution seems to have messed up the nesting of the profile tabs breaking them. Fixed here.
