### PR TITLE
Add http protocol to profile website if none exists

### DIFF
--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -37,6 +37,9 @@ block content
                     if userProfile.website
                         dt Website:
                         dd
+                            if (!userProfile.website.match(/^http[s]?:\/\//))
+                                - userProfile.website = 'http://' + userProfile.website
+                              
                             a(href='#{userProfile.website}', target='_blank') #{userProfile.website}
         .page-header
           ul.nav.nav-tabs


### PR DESCRIPTION
This fixes a bug on the users' news page where an incorrect URL might be displayed.

Pullup's user news page (example: http://pullup.io/news/user/megamattron) pulls GitHub profile data to build the section in the top-right corner. If a user fills out their GitHub profile's URL field without a protocol (like http or https), this produces an incorrect link on Pullup.

This change adds the http:// protocol if none exists. Note that no permanent change is made, it's just in the display of the link at runtime. I believe this is how GitHub handles it, too.
