### PR TITLE
added block styling to comment images - fixes #243

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -213,7 +213,7 @@ body {
   background-color: #f6f7f8;
   position: relative;
 
-  img {
+  img:not(.emoji) {
     display: block;
   }
 }


### PR DESCRIPTION
Added block styling to images in comments. This fix will apply the block styling to images in any comment, should this just apply to comments on issues?
