### PR TITLE
Don't mark your comments as unread

### DIFF
--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -103,7 +103,7 @@ block content
                                         small #{item.comment_count}
                                         small.hidden-xs  comments
                                         i.fa.fa-comment-o.hidden-sm.hidden-md.hidden-lg
-                            if item.comment_count > 0
+                            if item.latestCommentAt > 0
                                 small.hidden-xs.text-muted(title="#{item.latestCommentAt}")  (last comment #{timeago(item.latestCommentAt)})
                         p(class='hidden summary')
                             em= item.summary
@@ -148,7 +148,7 @@ block content
                                         small  1 comment
                                     default
                                         small  #{comment.newsItem.comment_count} comments
-                            if comment.newsItem.comment_count > 0
+                            if comment.newsItem.latestCommentAt > 0
                                 small.hidden-xs.text-muted(title="#{comment.newsItem.latestCommentAt}")  (last comment #{timeago(comment.newsItem.latestCommentAt)})
 
     if page > 1


### PR DESCRIPTION
This changes the way that the last comment is pulled for news items so that a story doesn't look like it has new comments if you were the last person to comment on it.
