### PR TITLE
fix ipad designs

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -206,7 +206,7 @@ body {
         }
       }
     }
-    @media (max-width: @screen-sm-min) {
+    @media (max-width: 767px) {
       li.news-item {
         position: relative;
         padding: 0;


### PR DESCRIPTION
There is 1 freaking pixel between the sm and xs breakpoints in bootstrap, and luckily that is right where iPad lands..  It's almost impossible to notice it if you're testing reflexive in a desktop browser.

Anyways, this fix shifts the iPhone designs down 1 pixel so that they don't apply to iPad.  Now the iPad just gets the regular desktop interface.  I think that's _fine_ - it might be nice to have custom iPad styles, but I don't think that'll be necessary for a long time.

Solves #257
