### PR TITLE
fixed upvote increment issue

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
           if (data.success) {
             $('button.upvote', form).remove();
 
-            var voteElement = $('.vote-count', form.closest('tr'));
+            var voteElement = $('.vote-count', form.closest('.news-item'));
             voteElement.text(parseInt(voteElement.text()) + 1);
           }
         })


### PR DESCRIPTION
Broke because the `table` was changed to a `ul`.

Now updated to look for the `.news-item` class instead as this would have prevented the break.
