### PR TITLE
Recover Process on Exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ logs
 results
 tmp
 
+.env
+
 npm-debug.log
 node_modules
 .idea

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: node forever.js

--- a/Procfile.local
+++ b/Procfile.local
@@ -1,2 +1,2 @@
-web: node app.js
+web: node forever.js
 mongo: mongod

--- a/forever.js
+++ b/forever.js
@@ -1,0 +1,11 @@
+  var forever = require('forever-monitor');
+
+  var child = new (forever.Monitor)('app.js', {
+    max: 3
+  });
+
+  child.on('exit', function () {
+    console.warn('app.js has exited after 3 restarts');
+  });
+
+  child.start();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express-flash": "~0.0.2",
     "express-validator": "~1.0.1",
     "fbgraph": "~0.2.8",
+    "forever-monitor": "~1.2",
     "github-api": "~0.7.0",
     "github": "~0.1",
     "jade": "~1.1.5",


### PR DESCRIPTION
This PR adds the forever module to restart the node process when an exception is encountered. It only restarts it 3 times, so the root cause needs to be addressed, but it's better than the current result.
