### PR TITLE
Make all the upvote arrows line up

### DIFF
--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -56,7 +56,8 @@ block content
       div#news.tab-pane.fade.in.active
         ul
             li.row.headers.hidden-xs
-                div.col-sm-2.col-lg-1.text-muted #
+                div.col-sm-2.col-lg-1.text-muted
+                    div.col-sm-1 #
                 div.col-sm-1 Votes
                 div.col-sm-6.col-lg-7 Title
                 if !filteredSource
@@ -64,7 +65,7 @@ block content
             each item, index in items
                 li.row.news-item
                     div.col-xs-2.col-sm-2.col-lg-1.upvote-wrapper
-                        span.hidden-xs.text-muted= index + 1
+                        span.hidden-xs.text-muted.col-sm-1= index + 1
                         if !item.votedFor
                             form(action='/news/' + item._id, method='POST', class='upvote-form')
                                 input(type='hidden', name='amount', value='1')


### PR DESCRIPTION
The upvote arrows get misaligned when the post number goes from 9 to 10.

![image](https://f.cloud.github.com/assets/113860/2322867/e7e43b0a-a3b5-11e3-97d3-dfa0853ff54f.png)
