### PR TITLE
Show news item summary

### DIFF
--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -14,7 +14,7 @@ block content
                     | ...
             +delete(item.poster, '/news/' + item._id + '/delete')
         h4
-          div(class="item-summary #{item.isSelfPost() ? '' : 'hidden'}")!= item.summary
+          div(class="item-summary")!= item.summary
         = 'submitted '
         span.timeago(title="#{item.created}")= timeago(item.created)
         = ' by '


### PR DESCRIPTION
When viewing comments now, you can not see the summary.

I can not think of a reason we would hide the news item summary.
