### PR TITLE
Fixes #312 - Previewing markdown doesn't load if empty 

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -81,7 +81,7 @@ exports.getMarkdown = function(req, res) {
   if(req.body.source === ''){
     return res.send({
       result: ''
-    })
+    });
   }
 
   return res.send({


### PR DESCRIPTION
Pretty simple fix. I probably could have left this for a new user but I was already in there.
