### PR TITLE
New URL for Gitter chat frame client

### DIFF
--- a/views/chat/index.jade
+++ b/views/chat/index.jade
@@ -2,4 +2,4 @@ extends ../layout
 
 block content
   div#chat.container
-    iframe(src="https://gitter.im/larvalabs/pullup/chat")
+    iframe(src="https://gitter.im/larvalabs/pullup/~chat")


### PR DESCRIPTION
Hello people of pullup!

Andrew from Gitter here. We couldn't help but notice the way you guys are embedding Gitter. Although what you've done to is not officially supported nor endorsed, we're glad you're using our product in innovative and interesting way! Obviously in future we may consider building an official embedding API and when we do, we'll definitely consult with you.

This pull request is just a heads-up to let you know that the iframe client URL is going to be changing in the next few days to make way for some new features which would otherwise clash with the old `/chat` url. When the release goes live, merging this PR in will fix your site when it breaks.

I'll try my best to give you some notice of the update going into production.

Regards,
Andrew
