### PR TITLE
Sort comments by date

### DIFF
--- a/config/userlist.js
+++ b/config/userlist.js
@@ -71,6 +71,7 @@ module.exports = {
         'sp1d3rx',
         'sriehl',
         'swelham',
+        'tdhsmith',
         'tejohnso',
         'testuser1',
         'theprofessor117',

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -84,6 +84,7 @@ exports.comments = function (req, res, next) {
           item: newsItem._id,
           itemType: 'news'
         })
+        .sort({created: 1})
         .populate('poster')
         .exec(cb);
       }


### PR DESCRIPTION
According to #290, some comments are appearing out of chronological order. This adds an explicit date-sort query when getting news item comments.  (Also adds me to userlist.)

I'm quite inexperienced at database wizardry, but after reading around<sup>[1]</sup> I suspect the issue is due to deletions. MongoDB's natural order isn't guaranteed to be identical to insertion order when documents are updated or removed, so occasionally comments from the same thread might be "jumping ahead" into an open database spot.

In any case, sorting the results before using them will solve the surface problem.
1. http://stackoverflow.com/a/11599283
