### PR TITLE
hide news feed on xs

### DIFF
--- a/views/partials/newsfeed.jade
+++ b/views/partials/newsfeed.jade
@@ -1,2 +1,2 @@
-.col-md-2.hidden-sm.news-feed
+.col-md-2.hidden-xs.news-feed
   .loading-animation.hide


### PR DESCRIPTION
Go figure, `xs` is smaller than `sm`..  heh, I'm a dope.

This fixes a bug that caused the news feed to reappear on mobile, entirely covering the main discussions feed.
