### PR TITLE
Fix GitHub auth

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -120,9 +120,15 @@ passport.use(new GitHubStrategy(secrets.github, function(req, accessToken, refre
         done(err, existingUser);
       });
     }
+
+    if(!profile.verifiedPrimaryEmail) {
+      req.flash('errors', { msg: 'You need a verified email on GitHub to use Pullup.'});
+      return done();
+    }
+
     var user = new User();
     user.username = profile.username;
-    user.email = profile._json.email;
+    user.email = profile.verifiedPrimaryEmail;
     user.github = profile.id;
     replaceToken(user, 'github', accessToken);
     user.profile.name = profile.displayName;

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -17,7 +17,7 @@ module.exports = {
     clientID: process.env.GITHUB_CLIENTID,
     clientSecret: process.env.GITHUB_SECRET,
     callbackURL: process.env.GITHUB_CALLBACK ||  '/auth/github/callback',
-    scope: ['public_repo'],
+    scope: ['public_repo', 'user:email'],
     passReqToCallback: true
   },
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "octonode": "~0.5.0",
     "passport": "~0.2.0",
     "passport-facebook": "~1.0.2",
-    "passport-github": "~0.1.5",
+    "passport-github": "git+https://git@github.com/alexgorbatchev/passport-github.git#9fef321dc7237c977b81fbf4a4f9589fc8ae9aaf",
     "passport-google-oauth": "~0.1.5",
     "passport-local": "~0.1.6",
     "passport-oauth": "~1.0.0",


### PR DESCRIPTION
When creating a new user, the current GitHub auth doesn't retrieve the user's email address properly (I think due to a change in GitHub's API).

this PR fixes that, and provides an error message if a user doesn't have a GitHub email address.