### PR TITLE
don't send an email to the poster of the comment

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -206,7 +206,7 @@ exports.postComment = function (req, res, next) {
 
       var newsPoster = results.newsItem.poster;
 
-      if (newsPoster.email) {
+      if (newsPoster.email && newsPoster.email !== req.user.email) {
         var email = new sendgrid.Email({
           to: newsPoster.email,
           from: 'noreply@pullup.io',


### PR DESCRIPTION
Right now, if you comment on your own news item, you get an email notifying you that someone commented. This change removes the unnecessary email.