### PR TITLE
update readme, no need for quotes around env variables when setting them

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ npm install -g gulp
 
 # Set the following environment variables:
 
-export GITHUB_CLIENTID='CLIENTID'
-export GITHUB_SECRET='SECRET'
+export GITHUB_CLIENTID=CLIENTID
+export GITHUB_SECRET=SECRET
 
 # Or, on Windows...
 


### PR DESCRIPTION
Remove quotes around env variables when setting them in README.md
issue #375 