### PR TITLE
Issue#349 Ability to view markdown source on comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ npm install -g gulp
 
 # Set the following environment variables:
 
-export GITHUB_CLIENTID='CLIENTID'
-export GITHUB_SECRET='SECRET'
+export GITHUB_CLIENTID=CLIENTID
+export GITHUB_SECRET=SECRET
 
 # Or, on Windows...
 

--- a/config/userlist.js
+++ b/config/userlist.js
@@ -1,6 +1,7 @@
 module.exports = {
     users: [ // ADD YOUR USERNAME IN ITS ALPHABETICAL SLOT
         'andersos',
+        'arminkhoshbin'
         'avaynshtok',
         'barretts',
         'bluetidepro',

--- a/config/userlist.js
+++ b/config/userlist.js
@@ -1,7 +1,7 @@
 module.exports = {
     users: [ // ADD YOUR USERNAME IN ITS ALPHABETICAL SLOT
         'andersos',
-        'arminkhoshbin'
+        'arminkhoshbin',
         'avaynshtok',
         'barretts',
         'bluetidepro',

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -126,6 +126,7 @@ exports.show = function (req, res, next) {
       issue.body = parseMarkdown(issue.body);
 
       _.each(results.comments, function (comment,i,l) {
+        comment.mdBody = comment.body;
         comment.body = parseMarkdown(comment.body);
       });
 

--- a/views/issues/show.jade
+++ b/views/issues/show.jade
@@ -21,3 +21,16 @@ block content
         span.timeago(title="#{comment.created_at}")= timeago(comment.created_at)
         blockquote.content
             != comment.body
+            button.btn.btn-primary(data-toggle='modal', data-target='##{index}modal', style= 'float: right;') View MD Source
+            div(style= 'clear:both;')
+        div(id= index + 'modal', tabindex= "-1", role= "dialog").modal.fade
+          div.modal-dialog
+            div.modal-content
+              div.modal-header
+                button.close(data-dismiss= "modal")
+                  span(aria-hidden= "true", st) &times;
+                h4.modal-title
+                  Comment MD Source
+              div.modal-body
+                textarea(readonly, style="width: 100%; height: 300px;")
+                  #{comment.mdBody}


### PR DESCRIPTION
This PR addresses issue #349.

View MD Source button has been added at the bottom of comment sections in issues.

![image](http://i.imgur.com/53xZf2t.png)

on click of the button you will be shown a modal with markdown source of the comment as it's shown below.

![Imgur](http://i.imgur.com/TKqoghG.png)