### PR TITLE
[AUTH] Limit github permissions

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -17,7 +17,7 @@ module.exports = {
     clientID: process.env.GITHUB_CLIENTID,
     clientSecret: process.env.GITHUB_SECRET,
     callbackURL: process.env.GITHUB_CALLBACK ||  '/auth/github/callback',
-    scope: ['public_repo', 'user:email'],
+    scope: ['user:email'],
     passReqToCallback: true
   },
 


### PR DESCRIPTION
## Overview

This PR removes `public_repo` from the GitHub auth scopes.

Closes https://github.com/larvalabs/pullup/issues/366

## Screen

![](http://dp.hanlon.io/1X032A2m3d2u/Image%202016-03-02%20at%208.28.33%20PM.png)

