### PR TITLE
[ACCOUNT] Change menu items

### DIFF
--- a/views/partials/navigation.jade
+++ b/views/partials/navigation.jade
@@ -31,7 +31,7 @@
               | #{user.username || user.profile.name || user.email || user.id}&nbsp;
               i.caret
             ul.dropdown-menu
-              li: a(href='/account') Account Settings
+              li: a(href='/account') Settings
               li.divider
               li: a(href='/news/user/#{user.username}') Profile
               li.divider

--- a/views/partials/navigation.jade
+++ b/views/partials/navigation.jade
@@ -31,8 +31,8 @@
               | #{user.username || user.profile.name || user.email || user.id}&nbsp;
               i.caret
             ul.dropdown-menu
-              li: a(href='/account') My Account
+              li: a(href='/account') Account Settings
               li.divider
-              li: a(href='/news/user/#{user.username}') My News
+              li: a(href='/news/user/#{user.username}') Profile
               li.divider
               li: a(href='/logout') Logout


### PR DESCRIPTION
## Overview

This PR changes the profile menu item names.

`My Account => Settings`
`My News => Profile`

## Motivation

While editing my profile I couldn't find a link to view my profile. I finally found it buried in the menu as `My News`. This is actually the profile page (though the URL still has `news` in it).

## Screen

![](http://dp.hanlon.io/0K2G3y1o2U3O/Image%202016-03-02%20at%209.01.15%20PM.png)