### PR TITLE
[PROFILE] Add user contributions

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -355,16 +355,19 @@ exports.userNews = function(req, res, next) {
         comment.contents = markdownParser(utils.replaceUserMentions(comment.contents));
       });
 
-      res.render('news/index', {
-        title: 'Posts by ' + user.username,
-        tab: 'news',
-        items: results.newsItems,
-        comments: results.comments,
-        filteredUser: user.username,
-        filteredUserWebsite: user.profile.website,
-        userProfile: user.profile
+      githubContributors.getPulls(function(data){
+        var pulls = githubContributors.getPullsForUser(user.username, data);
+        res.render('news/index', {
+          title: 'Posts by ' + user.username,
+          tab: 'news',
+          items: results.newsItems,
+          comments: results.comments,
+          contributions: pulls,
+          filteredUser: user.username,
+          filteredUserWebsite: user.profile.website,
+          userProfile: user.profile
+        });
       });
-
     });
   });
 };

--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -161,7 +161,7 @@ body {
 // News & Issues Table
 // -------------------------
 
-#news, #issues, #user-comments {
+#news, #issues, #user-comments, #user-contributions {
   ul {
     padding: 0;
     list-style-type: none;

--- a/views/news/index.jade
+++ b/views/news/index.jade
@@ -54,6 +54,9 @@ block content
             li
               a(href='#user-comments', data-toggle='tab')
                 h4 Comments
+            li
+               a(href='#user-contributions', data-toggle='tab')
+                h4 Contributions
 
     div.tab-content
       div#news.tab-pane.fade.in.active
@@ -159,6 +162,22 @@ block content
                                         small  #{comment.newsItem.comment_count} comments
                             if comment.newsItem.comment_count > 0
                                 small.hidden-xs.text-muted(title="#{comment.newsItem.latestCommentAt}")  (last comment #{timeago(comment.newsItem.latestCommentAt)})
+
+        div#user-contributions.tab-pane.fade
+          ul
+            li.row.headers.hidden-xs
+                div.col-sm-1.text-muted PR #
+                div.col-sm-7 Title
+                div.col-sm-4
+            each contribution, index in contributions
+                li.row.news-item
+                  div.col-sm-1
+                      a(href="#{contribution.html_url}", target="_blank")="#" + contribution.number
+                  div.col-sm-7
+                      span=contribution.title
+                  div.col-sm-4
+                    span=timeago(contribution.created_at)
+
 
     if page > 1
         a(href=(page-1), class='btn btn-sm btn-default')


### PR DESCRIPTION
## Overview

This PR adds user contributions (pull requests) to the user profile pages.

Closes https://github.com/larvalabs/pullup/issues/305

## Note

This feature is currently desktop only. In order to enable mobile we'll need to fix the tab overflow with the new tab (a good beginner issue):

![](http://dp.hanlon.io/2G2L1y3R273X/Image%202016-03-03%20at%205.01.23%20PM.png)

## Screen

![](http://dp.hanlon.io/0J0w1d3B0m2Z/Image%202016-03-03%20at%204.59.43%20PM.png)