### PR TITLE
Fix bad markup in “View MD Source” modal

### DIFF
--- a/views/issues/show.jade
+++ b/views/issues/show.jade
@@ -30,7 +30,7 @@ block content
                 button.close(data-dismiss= "modal")
                   span(aria-hidden= "true", st) &times;
                 h4.modal-title
-                  Comment MD Source
+                  | Comment’s Markdown Source
               div.modal-body
                 textarea(readonly, style="width: 100%; height: 300px;")
-                  #{comment.mdBody}
+                  = comment.mdBody


### PR DESCRIPTION
With the old markup, every popup contained the text twice, in opening and closing HTML tags, like this:

    <@chall8908 I really like that. That's also great for mobile devices which are inherently bad at displaying nested content inline.></@chall8908 I really like that. That's also great for mobile devices which are inherently bad at displaying nested content inline.>

This change makes the content display correctly. I also improved the modal’s title, which used to render as just “MD Source”.

An example page with “View MD Source” buttons is <http://pullup.io/issues/52fd2ba01ea7d102006e333f>.

(I am already in [the user list](https://github.com/larvalabs/pullup/blob/master/config/userlist.js).)