### PR TITLE
Make ”View MD Source” buttons less conspicuous

### DIFF
--- a/views/issues/show.jade
+++ b/views/issues/show.jade
@@ -21,7 +21,7 @@ block content
         span.timeago(title="#{comment.created_at}")= timeago(comment.created_at)
         blockquote.content
             != comment.body
-            button.btn.btn-primary(data-toggle='modal', data-target='##{index}modal', style= 'float: right;') View MD Source
+            button.btn.btn-link.btn-xs(data-toggle='modal', data-target='##{index}modal', style= 'float: right;') View MD Source
             div(style= 'clear:both;')
         div(id= index + 'modal', tabindex= "-1", role= "dialog").modal.fade
           div.modal-dialog


### PR DESCRIPTION
They are rarely-used and relatively unimportant, so they shouldn’t look that eye-catching or take up so much screen real estate.

[A test page](http://pullup.io/issues/52fd2ba01ea7d102006e333f)

### Before

![before, with a large, contrasting button](https://cloud.githubusercontent.com/assets/79168/13546915/61c2c2d8-e28a-11e5-9953-dd137637e965.png)

### After

![after, with a small button that looks like a link](https://cloud.githubusercontent.com/assets/79168/13546930/ddb1c484-e28a-11e5-9e48-56262fcf2af1.png)