### PR TITLE
[NEWS] Add new news

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,6 +167,8 @@ app.get('/account/unlink/:provider', passportConf.isAuthenticated, userControlle
 
 app.get('/news', newsController.index);
 app.get('/news/page/:page', newsController.index);
+app.get('/news/new', newsController.new);
+app.get('/news/new/page/:page', newsController.new);
 app.get('/rss', newsController.index);
 app.get('/news/submit', passportConf.isAuthenticated, newsController.submitNews);
 app.post('/news/submit', passportConf.isAuthenticated, newsController.postNews);

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -44,13 +44,38 @@ exports.index = function(req, res, next) {
 
     res.render(view, {
       title: 'Top News',
-      tab: 'news',
+      tab: 'top',
       items: newsItems,
       page: page,
       archive: page > maxPages,
       newsItemsPerPage: newsItemsPerPage
     });
   }, sortByScore);
+};
+
+exports.new = function(req, res, next) {
+
+  var page = typeof req.params.page !== 'undefined' ? req.params.page : 1;
+  page = isNaN(page) ? 1 : Number(page);
+  page = page < 1 ? 1 : page;
+
+  // don't use a `/page/1` url
+  if(req.params.page === '1') return res.redirect(req.url.slice(0, req.url.indexOf('page')));
+
+  var view = 'news/index';
+
+  getNewsItems({}, page, req.user, function (err, newsItems) {
+    if(err) return next(err);
+
+    res.render(view, {
+      title: 'Newest',
+      tab: 'new',
+      items: newsItems,
+      page: page,
+      archive: page > maxPages,
+      newsItemsPerPage: newsItemsPerPage
+    });
+  }, sortByNewest);
 };
 
 /**
@@ -559,6 +584,14 @@ function sortByScore(newsItems) {
   // sort with highest scores first
   newsItems.sort(function (a,b) {
     return b.score - a.score;
+  });
+
+  return newsItems;
+}
+
+function sortByNewest(newsItems) {
+  newsItems.sort(function (a,b) {
+    return b.created.getTime() - a.created.getTime();
   });
 
   return newsItems;

--- a/views/partials/navigation.jade
+++ b/views/partials/navigation.jade
@@ -9,8 +9,10 @@
       a.navbar-brand(href='/') pullup
     .collapse.navbar-collapse
       ul.nav.navbar-nav
-        li.hidden-xs(class=tab=='news'?'active':undefined)
-          a(href='/news') News
+        li.hidden-xs(class=tab=='top'?'active':undefined)
+          a(href='/news') Top
+        li.hidden-xs(class=tab =='new' ? 'active' : undefined)
+          a(href='/news/new') New
         li.hidden-xs(class=tab=='issues'?'active':undefined)
           a(href='/issues') Issues
         li.hidden-xs


### PR DESCRIPTION
## Overview

This PR adds a route for newest news.

Closes https://github.com/larvalabs/pullup/issues/107

## Details
Changes the navigation from just `News` to `Top | New`. 

I'm not _crazy_ about this, but the adding a sort option on the news page is pretty involved and I'm still thinking through how to improve the project structure to make that sort of change easier.

## Screen
![](http://dp.hanlon.io/2G1K3l3v0I3j/Image%202016-03-08%20at%205.14.54%20PM.png)
