### PR TITLE
Add text when logged out and no comments

### DIFF
--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -40,3 +40,6 @@ block content
         blockquote.content
             +delete(comment.poster, '/news/' + item.id + '/comments/' + comment.id + '/delete')
             != comment.contents
+
+    if !user && comments.length == 0
+        include ../partials/nocomments

--- a/views/partials/nocomments.jade
+++ b/views/partials/nocomments.jade
@@ -1,0 +1,6 @@
+if !user
+    div.comment
+        blockquote.content
+            p
+            strong="There are no comments. "
+            span Join this site via pull request to be the first!


### PR DESCRIPTION
## Overview

This PR adds a small text block for logged out users when there are no comments on an item.

## Screen

#### Before
![](http://dp.hanlon.io/3L0B2a0M3Z1H/Image%202016-03-22%20at%203.34.03%20PM.png)

#### After
![](http://dp.hanlon.io/0D3r1s1e1c26/Image%202016-03-22%20at%203.33.26%20PM.png)