### PR TITLE
Hide upvote if user has voted for item

### DIFF
--- a/controllers/votes.js
+++ b/controllers/votes.js
@@ -99,7 +99,7 @@ exports.addVotesToItem = function (item, item_id, user, votes) {
     .reduce(function (prev, curr, i) {
 
       // count this item as voted for if the logged in user has a vote tallied
-      if(user && user.id && curr.voter.toString() === user.id.toString()) {
+      if(user && user.id && curr.voter.id.toString() === user.id.toString()) {
         item.votedFor = true;
       }
 

--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -161,7 +161,20 @@ body {
 // News & Issues Table
 // -------------------------
 
-#news, #issues, #user-comments, #user-contributions {
+#news, #issues, #user-comments, #user-contributions, #news-show {
+  .upvote-form {
+    display: inline-block;
+    position: relative;
+
+    .upvote {
+      border: none;
+      background: none;
+      &:hover {
+        color: #18bc9c;
+      }
+    }
+  }
+
   ul {
     padding: 0;
     list-style-type: none;
@@ -208,18 +221,8 @@ body {
         }
 
         .upvote-form {
-          display: inline-block;
-          position: relative;
           left: 50%;
           margin-left: -15px;
-
-          .upvote {
-            border: none;
-            background: none;
-            &:hover {
-              color: #18bc9c;
-            }
-          }
         }
       }
     }

--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -8,7 +8,7 @@ block content
     .page-header
         h3
             span.vote-count=votes.votes
-            if !item.votedFor
+            if !votes.votedFor
                 form(action='/news/' + item._id, method='POST', class='upvote-form')
                     input(type='hidden', name='amount', value='1')
                     button(type='submit', class='upvote')

--- a/views/news/show.jade
+++ b/views/news/show.jade
@@ -2,12 +2,18 @@ extends ../layout
 include ../mixins/delete
 
 block content
-  div.news-item
+  #news-show.news-item
     include ../partials/joinsite
 
     .page-header
         h3
             span.vote-count=votes.votes
+            if !item.votedFor
+                form(action='/news/' + item._id, method='POST', class='upvote-form')
+                    input(type='hidden', name='amount', value='1')
+                    button(type='submit', class='upvote')
+                        i.fa.fa-chevron-up
+
             a(href=item.url)= item.title
             if item.summary && ! item.isSelfPost()
                 | &nbsp;


### PR DESCRIPTION
## Overview

This PR fixes a bug to hide the upvote button if the user has already voted for an item. It also hides the upvote on the comment page in https://github.com/larvalabs/pullup/pull/406 (and thus depends on that PR).

Closes https://github.com/larvalabs/pullup/issues/405.

## Desktop

![](http://dp.hanlon.io/1J2y3d1T0x3y/Image%202016-03-31%20at%201.57.14%20PM.png)

## Mobile

![](http://dp.hanlon.io/1j0F470X360H/Image%202016-03-31%20at%202.00.04%20PM.png)