### PR TITLE
Add backend check for deletes

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -228,12 +228,25 @@ exports.deleteComment = function (req, res, next) {
   }
 
   Comment
-    .findByIdAndRemove(req.params.comment_id)
+    .findById(req.params.comment_id)
     .exec(function(err, comment) {
       if (err) res.redirect('back');
 
-      req.flash('success', { msg: 'Comment deleted.' });
-      res.redirect('back');
+      if (req.user.id.toString() !== comment.poster.toString()){
+        req.flash('errors', [{
+          param: 'user',
+          msg: 'You do not have access to delete this comment.',
+          value: undefined
+        }]);
+        return res.redirect('back');
+      }
+
+      comment.remove(function(err){
+        if (err) res.redirect('back');
+
+        req.flash('success', { msg: 'Comment deleted.' });
+        res.redirect('back');
+      })
     });
 };
 

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -246,7 +246,7 @@ exports.deleteComment = function (req, res, next) {
 
         req.flash('success', { msg: 'Comment deleted.' });
         res.redirect('back');
-      })
+      });
     });
 };
 

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -94,22 +94,38 @@ exports.deleteNewsItemAndComments = function (req, res, next) {
     return res.redirect('back');
   }
 
-  async.parallel({
-    newsItem: function(cb) {
-      NewsItem
-      .findByIdAndRemove(req.params.id)
-      .exec(cb);
-    },
-    comments: function(cb) {
-      Comment
-      .remove({item: req.params.id}, cb);
-    }
-  }, function (err, results) {
-    if (err) res.redirect('back');
+  NewsItem
+    .findById(req.params.id)
+    .exec(function(err, newsItem){
 
-    req.flash('success', { msg: 'News item and comments deleted.' });
-    res.redirect('/news');
-  });
+      if(req.user.id.toString() !== newsItem.poster.toString()){
+        req.flash('errors', [{
+          param: 'user',
+          msg: 'You do not have access to delete this itek.',
+          value: undefined
+        }]);
+        return res.redirect('back');
+      }
+
+      async.parallel({
+        newsItem: function(cb) {
+          NewsItem
+            .findByIdAndRemove(req.params.id)
+            .exec(cb);
+        },
+        comments: function(cb) {
+          Comment
+            .remove({item: req.params.id}, cb);
+        }
+      }, function (err, results) {
+        if (err) res.redirect('back');
+
+        req.flash('success', { msg: 'News item and comments deleted.' });
+        res.redirect('/news');
+      });
+    });
+
+
 };
 
 /**


### PR DESCRIPTION
## Overview

This PR adds a backend check for comment deletes to ensure the only the creator can delete the comment.

Closes https://github.com/larvalabs/pullup/issues/410

## Screen
On error:

![](http://dp.hanlon.io/2Y2126241f1I/Image%202016-04-04%20at%2012.23.19%20PM.png)

Note: this shows Matt logged in, but that's an related bug fixed in https://github.com/larvalabs/pullup/commit/ecbb9cda6cd42a186f7b8348cbefe7e089ff3dce. I'm actually the user logged in here, so I should not have access to delete his comments.